### PR TITLE
Perf: improve performance of `Publications` list and search

### DIFF
--- a/src/pages/Publications/Publication/Publication.jsx
+++ b/src/pages/Publications/Publication/Publication.jsx
@@ -1,7 +1,14 @@
+import React from "react";
 import PropTypes from "prop-types";
 import "./Publication.scss";
 
-const Publication = function ({ title, year, instruments, description, link }) {
+const Publication = React.memo(function Publication({
+	title,
+	year,
+	instruments,
+	description,
+	link,
+}) {
 	const instrumentElements = instruments.map((instrument, i) => (
 		<li key={i} className="publication__instrument small">
 			{instrument}
@@ -17,12 +24,11 @@ const Publication = function ({ title, year, instruments, description, link }) {
 			</header>
 			<p className="publication__description">{description}</p>
 			<a href={link} target="_blank" className="publication__link">
-				View on score on Composers Edition ➞{" "}
-				<span className="new-tab-message">(opens in new tab)</span>
+				View score on Composers Edition ➞<span className="new-tab-message">(opens in new tab)</span>
 			</a>
 		</article>
 	);
-};
+});
 
 Publication.propTypes = {
 	title: PropTypes.string.isRequired,

--- a/src/pages/Publications/Publications.jsx
+++ b/src/pages/Publications/Publications.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useDeferredValue, useEffect, useRef, useState } from "react";
 import Publication from "./Publication/Publication";
 import pubsData from "/src/data/publications.json";
 import "./Publications.scss";
@@ -7,7 +7,9 @@ const Publications = function () {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [sortType, setSortType] = useState("year-desc");
 	const [dropdownOpen, setDropdownOpen] = useState(false);
+
 	const dropdownRef = useRef(null);
+	const deferredQuery = useDeferredValue(searchQuery);
 
 	useEffect(() => {
 		const handleClickOutside = e => {
@@ -32,7 +34,7 @@ const Publications = function () {
 	};
 
 	const filteredPubs = pubsData.filter(pub =>
-		pub.title.toLowerCase().includes(searchQuery.toLowerCase())
+		pub.title.toLowerCase().includes(deferredQuery.toLowerCase())
 	);
 	const sortedPubs = [...filteredPubs].sort(sortStrategies[sortType] || (() => 0));
 


### PR DESCRIPTION
- Memoize `Publication` to prevent re-renders when updating publications list for user search.
- Defer search results to prevent rapid re-renders when user is typing.